### PR TITLE
Add script and for for accessing MOSRS branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,18 @@ any changes:
 
 MOSRS uses SVN which can be used from git using `git svn`. The way this is done
 is to set up a `svn-remote` (pointing to a specific SVN path, for example
-`trunk`) and then fetching this content. Each commit on the MOSRS SVN will then
-have an corresponding git commit. Adding and accessing `trunk` from MOSRS can
-be done with the following commands:
+`trunk`) and then fetching this content. Each commit on the MOSRS SVN will
+then have an corresponding git commit. Adding and accessing `trunk` (or
+any other branch) from MOSRS can be done with the script in
+[utils/add_mosrs_remote.sh](utils/add_mosrs_remote.sh). This script
+ensures that your local `master` is in sync with `master` on the Leeds
+fork, fetches the remote content from MOSRS, creates a branch from that
+content and ensures the history syncs up.
 
-```bash
-export LOCAL_NAME="mosrs-trunk"
-git config --add svn-remote.${LOCAL_NAME}.url https://code.metoffice.gov.uk/svn/monc/main/trunk
-git config --add svn-remote.${LOCAL_NAME}.fetch :refs/remotes/mosrs/trunk
-git svn fetch ${LOCAL_NAME}
-git checkout remotes/mosrs/trunk -b ${LOCAL_NAME}
-unset LOCAL_NAME
-```
+    ```bash
+    $> ./utils/add_mosrs_remote.sh <mosrs_svn_remote_path> <local_branch_name>
+    ```
 
-You will need a user account for MOSRS to be able to run this command. Once
-done the entire history of `trunk` on MOSRS will then be available on the git
-branch called `mosrs-trunk`, which can then be merged into the current branch.
+You will need a user account for MOSRS to be able to run this command.
+Once done the entire history on MOSRS will then be available on the to git
+(and can be merged into existing branches etc).

--- a/add_mosrs_remote.sh
+++ b/add_mosrs_remote.sh
@@ -1,0 +1,61 @@
+# Script to add a MOSRS branch to your local git repository
+
+
+if [ "$#" -lt 2 ]; then
+  echo
+  echo "usage: $0 remote_svn_path local_branch_name"
+  echo
+  echo "   remote_svn_path:    the path on MOSRS where the branch you want to work on resides, e.g."
+  echo
+  echo "                        trunk"
+  echo "                        branches/pkg/adrianhill/vn0.9.0_to_0.9.x_part1_pkg"
+  echo "                        branches/dev/toddjones/r7304_tvfff/vn0.9.0_to_0.9.x_part1_pkg"
+  echo
+  echo "   local_branch_name:  the name you'd like you branch to have locally, e.g."
+  echo
+  echo "                        mosrs-trunk"
+  echo "                        adrianhill-vn0.9.0"
+  echo "                        toddjones-tvfff"
+  echo
+  echo "NOTE: before fetching the SVN branch your local 'master' branch"
+  echo "      will be made up-to-date with the 'master' branch of the"
+  echo "      Leeds MONC fork on github (https://github.com/Leeds-MONC/monc)"
+  exit 1
+fi
+
+REMOTE_SVN_PATH="$1"
+LOCAL_BRANCH_NAME="$2"
+
+if [ `git branch --list ${LOCAL_BRANCH_NAME}` ];
+then
+  echo "The local branch '${LOCAL_BRANCH_NAME}' already exists"
+  exit 1
+fi
+
+# ensure local master is up-to-date with upstream
+if git ls-remote --exit-code upstream &> /dev/null; then
+  echo
+else
+  git remote add upstream https://github.com/Leeds-MONC/monc
+fi
+
+git checkout master --quiet
+git pull upstream master --quiet
+
+if [ `git config svn-remote.${LOCAL_BRANCH_NAME}.url` ]; then
+  echo
+  echo "Some of the configuration for this SVN remote is already set"
+  echo "(maybe you've tried running this command already, but stopped it running?)"
+  echo
+  echo "Please delete this configuration by issuing the following commands:"
+  echo "  git config --remove-section svn-remote.${LOCAL_BRANCH_NAME}"
+  exit 1
+fi
+
+git config --add svn-remote.${LOCAL_BRANCH_NAME}.url https://code.metoffice.gov.uk/svn/monc/main/branches/pkg/adrianhill/vn0.9.0_to_0.9.x_part1_pkg
+git config --add svn-remote.${LOCAL_BRANCH_NAME}.fetch :refs/remotes/mosrs/${LOCAL_BRANCH_NAME}
+git svn fetch ${LOCAL_BRANCH_NAME}
+git checkout remotes/mosrs/${LOCAL_BRANCH_NAME} -b ${LOCAL_BRANCH_NAME}
+# ensure that the history syncs up so that revisions already associated with
+# git commits are identified
+git rebase master


### PR DESCRIPTION
Provide a utility script with the Leeds fork of MONC to easily add a
remote SVN branch on MOSRS to the local git repository so that changes
(from trunk or other branchas) can easily be pulled in.