### PR TITLE
ARC4 compilation script improvements for CASIM/SOCRATES

### DIFF
--- a/fcm-make/keyword-monc.cfg
+++ b/fcm-make/keyword-monc.cfg
@@ -39,3 +39,9 @@ location{primary}[monc-scripts.x] = https://code.metoffice.gov.uk/svn/monc/scrip
 location{primary}[monc-scripts.xm] = <Local mirror URL>
 browser.loc-tmpl[monc-scripts.x] = https://code.metoffice.gov.uk/trac/{1}/intertrac/source:/{2}{3}
 browser.comp-pat[monc-scripts.x] = (?msx-i:\A // [^/]+ /svn/ ([^/]+) /*(.*) \z)
+
+# Socrates
+location{primary}[socrates.x] = https://code.metoffice.gov.uk/svn/socrates/main
+location{primary}[socrates.xm] = <Local mirror URL>
+browser.loc-tmpl[socrates.x] = https://code.metoffice.gov.uk/trac/{1}/intertrac/source:/{2}{3}
+browser.comp-pat[socrates.x] = (?msx-i:\A // [^/]+ /svn/ ([^/]+) /*(.*) \z)

--- a/utils/arc/monc_compile_arc.sh
+++ b/utils/arc/monc_compile_arc.sh
@@ -5,7 +5,7 @@ if [ ! -f ~/.metomi/fcm/keyword.cfg ]; then
   mkdir -p ~/.metomi/fcm
   echo ${keywrdfile} > ~/.metomi/fcm/keyword.cfg
 else
-  if cat ~/.metomi/fcm/keyword.cfg | grep -q -v "${keywrdfile}"; then
+  if ! grep -q "${keywrdfile##* } ~/.metomi/fcm/keyword.cfg"; then
     echo ${keywrdfile} >> ~/.metomi/fcm/keyword.cfg
   fi
 fi

--- a/utils/arc/monc_compile_arc.sh
+++ b/utils/arc/monc_compile_arc.sh
@@ -11,13 +11,16 @@ else
 fi
 
 #Script to compile Monc on ARC4:
-
+. /nobackup/cemac/cemac.sh
 module purge
 module load user
 module switch intel gnu
 module switch openmpi mvapich2
 module load fftw netcdf hdf5 fcm
-. /nobackup/cemac/cemac.sh
+module load svn
+
+export PATH=/nobackup/cemac/mosrs:$PATH
+mosrs-setup-gpg-agent
 
 echo "Compile options: "
 echo "(1)   MONC Standalone,"

--- a/utils/arc/monc_compile_arc.sh
+++ b/utils/arc/monc_compile_arc.sh
@@ -1,11 +1,47 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
+keywrdfile=$( sed "s|= |= $( pwd -P )\/fcm-make\/|g" fcm-make/keyword.cfg )
+if [ ! -f ~/.metomi/fcm/keyword.cfg ]; then
+  mkdir -p ~/.metomi/fcm
+  echo ${keywrdfile} > ~/.metomi/fcm/keyword.cfg
+else
+  if cat ~/.metomi/fcm/keyword.cfg | grep -q -v "${keywrdfile}"; then
+    echo ${keywrdfile} >> ~/.metomi/fcm/keyword.cfg
+  fi
+fi
 
 #Script to compile Monc on ARC4:
 
 module purge
 module load user
-module switch intel gnu/8.3.0
-#module switch openmpi mvapich2
+module switch intel gnu
+module switch openmpi mvapich2
 module load fftw netcdf hdf5 fcm
+. /nobackup/cemac/cemac.sh
 
-fcm make -j4 -f fcm-make/monc-arc4-gnu.cfg
+echo "Compile options: "
+echo "(1)   MONC Standalone,"
+echo "(2)   MONC with CASIM,"
+echo "(3)   MONC with SOCRATES,"
+echo "(4)   MONC with CASIM and SOCRATES"
+echo ""
+echo "Select which option [1-4]: "
+read compileoption
+
+case $compileoption in
+1)
+  fcm make -j4 -f fcm-make/monc-arc4-gnu.cfg
+  ;;
+2)
+  fcm make -j4 -f fcm-make/monc-arc4-gnu.cfg -f fcm-make/casim.cfg
+  ;;
+3)
+  fcm make -j4 -f fcm-make/monc-arc4-gnu.cfg -f fcm-make/socrates.cfg
+  ;;
+4)
+  fcm make -j4 -f fcm-make/monc-arc4-gnu.cfg -f fcm-make/casim_socrates.cfg
+  ;;
+*)
+  echo "Unexpected compilation option. Should be an integer in the range 1-4"
+  ;;
+esac

--- a/utils/arc/monc_compile_arc.sh
+++ b/utils/arc/monc_compile_arc.sh
@@ -20,7 +20,7 @@ module load fftw netcdf hdf5 fcm
 module load svn
 
 export PATH=/nobackup/cemac/mosrs:$PATH
-mosrs-setup-gpg-agent
+. mosrs-setup-gpg-agent
 
 echo "Compile options: "
 echo "(1)   MONC Standalone,"

--- a/utils/arc/monc_compile_arc.sh
+++ b/utils/arc/monc_compile_arc.sh
@@ -5,7 +5,7 @@ if [ ! -f ~/.metomi/fcm/keyword.cfg ]; then
   mkdir -p ~/.metomi/fcm
   echo ${keywrdfile} > ~/.metomi/fcm/keyword.cfg
 else
-  if ! grep -q "${keywrdfile##* } ~/.metomi/fcm/keyword.cfg"; then
+  if ! grep -q "${keywrdfile##* }" ~/.metomi/fcm/keyword.cfg; then
     echo ${keywrdfile} >> ~/.metomi/fcm/keyword.cfg
   fi
 fi


### PR DESCRIPTION
Made modifications to ARC4 compilation script so that:
1. The keywords file is linked from the working versions fcm-make/keyword-monc.cfg file to the users ~/.metomi/fcm/keyword.cfg file, meaning the keywords file does not have to be populated manually
2. The mosrs password is cached so that branches and revisions can be checked out
3. a dialogue is given to the user to allow them to choose compiler options

This should remove much of the initial barrier to use for new users on arc4. Similar work has been done on the archer2 compatibility branch