### PR TITLE
add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Change Log
+
+## [Unreleased](https://github.com/Leeds-monc/monc/tree/HEAD)
+
+[Full Changelog](https://github.com/Leeds-monc/monc/compare/v0.9.0...HEAD)
+
+### New features
+
+- ARC4 compilation modifications and instructions (#28) by [Chris
+  Symonds](https://github.com/cemac-css)
+
+- Continuous integration testing with Travis (using simplified version of
+  Straka test case) (#9 and #10) by [Leif
+  Denby](https://github.com/leifdenby)
+
+
+### Bug fixes
+
+**Bugfixes**:
+
+- Fix for piecewise linear 1D interpolation (#35) by [Steven
+  Boeing](https://github.com/sjboeing)
+
+
+## [v0.9.0](https://github.com/Leeds-monc/monc/tree/v0.9.0) (2020-04-29)
+
+First tagged version representing fork from MOSRS repository at revision
+7765.


### PR DESCRIPTION
I've been thinking about how we can keep an up-to-date changelog for MONC, and here's my suggestion (modelling this on [xarray's "whats-new.rst" file](https://github.com/pydata/xarray/blob/master/doc/whats-new.rst)):

Once a pull-request has reached the final stages where we're happy for it to be merged the author of the pull-request should add a line to [CHANGELOG.md](https://github.com/leifdenby/monc/blob/add-changelog/CHANGELOG.md) in the "unreleased" section with one sentence summarising the change. This section will be split into at least "new features" and "bug fixes" subsections, and if the pull-request introduces a breaking change into should be a separate "breaking changes" subsection.

Sound ok @sjboeing, @cemac-ccs, @MarkUoLeeds, @ralphburton, @eers1?

We've already got a few changes since v0.9.0 (where we forked from MOSRS) so I think we should get this CHANGELOG added before we make any more additions/changes (e.g. #48, #47, #46)

Please check if you're happy with the format and what I've pull in the CHANGELOG so far: https://github.com/leifdenby/monc/blob/add-changelog/CHANGELOG.md (@sjboeing and @cemac-ccs in particular)